### PR TITLE
Fix issue where button is shown automatically

### DIFF
--- a/HideExpansionButton.lua
+++ b/HideExpansionButton.lua
@@ -1,13 +1,22 @@
 local frame = CreateFrame("FRAME", "HideExpansionButtonFrame")
 frame:RegisterEvent("ADDON_LOADED")
-frame:RegisterEvent("PLAYER_LOGIN")
+frame:RegisterEvent("COVENANT_CALLINGS_UPDATED")
+frame:RegisterEvent("PLAYER_ENTERING_WORLD")
 
-frame:SetScript("OnEvent", function(self, event, addon, ...)
-    if event == "ADDON_LOADED" and addon == "HideExpansionButton" then
-        if ExpansionButtonVisible == nil then
+frame:SetScript("OnEvent", function(self, event, ...)
+    if event == "ADDON_LOADED" then
+        local addonName = ...
+        if addonName == "HideExpansionButton" and ExpansionButtonVisible == nil then
             ExpansionButtonVisible = false
+            SetButtonState()
+            frame:UnregisterEvent("ADDON_LOADED")
         end
-    elseif event == "PLAYER_LOGIN" then
+    elseif event == "COVENANT_CALLINGS_UPDATED" then
+        -- Something fires this event and then turns the button back on after.
+        -- Since it doesn't seem to fire another event when it's done we just
+        -- have to wait an arbitrary amount of time.
+        C_Timer.After(5, SetButtonState)
+    else
         SetButtonState()
     end
 end)


### PR DESCRIPTION
Something firing the `COVENANT_CALLINGS_UPDATED` event and then turning the button back on. Since it doesn't fire a new event when it's done we just have to wait some arbitrary amount of time.